### PR TITLE
Fixed unclosed {foreach}  error

### DIFF
--- a/template/header.tpl
+++ b/template/header.tpl
@@ -39,7 +39,7 @@
   {foreach from=$themes item=theme}
   {if $theme.load_css}
     {assign var="csstheme" value="themes/`$theme.id`/theme.css"}
-    { if file_exists($csstheme) }
+    {if file_exists($csstheme)}
       {combine_css path="themes/`$theme.id`/theme.css" order=10}
     {/if}
   {/if}


### PR DESCRIPTION
Not sure if its a problem with Smarty3 in Piwigo 2.6.0RC2 or the error was always there but because of this extra space it wasn't compiling.
