### PR TITLE
{php} tag forbidden in Smarty 3 + Piwigo 2.7

### DIFF
--- a/template/stuffs_blocks.tpl
+++ b/template/stuffs_blocks.tpl
@@ -1,5 +1,3 @@
-{php}remove_event_handler('loc_end_index', 'hide_main_block');{/php}
-
 {foreach from=$blocks item=block key=key}
   <div class="stuffs_block">
     {if isset($block.TITLE)}


### PR DESCRIPTION
The problem has been solved in plugin PWG Stuffs, no need to pollute theme SimpleNG
