### PR TITLE
Remove hardcoded http protocol for Google Fonts

### DIFF
--- a/template/header.tpl
+++ b/template/header.tpl
@@ -30,7 +30,7 @@
   {if isset($last.U_IMG)}<link rel="last" title="{'Last'|@translate}" href="{$last.U_IMG}">{/if}
   {if isset($U_UP)}<link rel="up" title="{'Thumbnails'|@translate}" href="{$U_UP}">{/if}
 
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,400italic,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Open+Sans:400,400italic,700' rel='stylesheet' type='text/css'>
 
   {combine_css path="themes/simpleng/css/style.min.css" order="1"}
   {combine_css path="themes/simpleng/css/bootstrap-responsive.min.css" order="2"}


### PR DESCRIPTION
As mentionned in issue #21, the theme calls for Google fonts.
More than a privacy issue, that is not working in https servers.
This small change does not fix the privacy issue, but resolves the theme in https servers